### PR TITLE
Player ux war reveal

### DIFF
--- a/src/components/table/TableCardStack.css
+++ b/src/components/table/TableCardStack.css
@@ -7,6 +7,7 @@
   top: 20px;
 }
 
+
 .table_cardStack > :nth-child(3) {
   position: absolute;
   top: 40px;
@@ -15,4 +16,31 @@
 .table_cardStack > :nth-child(4) {
   position: absolute;
   top: 60px;
+}
+
+.showAll.table_cardStack > :nth-child(2) {
+  animation: move-down 0.5s;
+  animation-fill-mode: forwards;
+}
+
+.showAll.table_cardStack > :nth-child(3) {
+  animation: move-down-more 0.5s;
+  animation-fill-mode: forwards;
+}
+
+.showAll.table_cardStack > :nth-child(4) {
+  animation: move-down-most 0.5s;
+  animation-fill-mode: forwards;
+}
+
+@keyframes move-down {
+  100% {transform: translateY(40px)}
+}
+
+@keyframes move-down-more {
+  100% {transform: translateY(80px)}
+}
+
+@keyframes move-down-most {
+  100% {transform: translateY(120px)}
 }

--- a/src/components/table/TableCardStack.tsx
+++ b/src/components/table/TableCardStack.tsx
@@ -25,8 +25,11 @@ const TableCardStack = ({ player }: { player: Player }) => {
     game.stage === GameStage.WarScore ||
     game.stage === GameStage.WarReveal;
 
+  const showAll =
+    game.stage === GameStage.WarScore || game.stage === GameStage.Score;
+
   return (
-    <div className="table_cardStack">
+    <div className={`table_cardStack ${showAll ? "showAll" : ""}`}>
       {showSelectCard && <CardMaybeSelected card={player.selectedCard} />}
       {showWarCards && <CardMaybeSelected card={player.war.sacrifices[0]} />}
       {showWarCards && player.war.sacrifices[0] && (


### PR DESCRIPTION
Animate the cards on war reveal to show them all.

Note: The time is short still because we will have to refactor to make the Score stage a little longer. Once it's refactored, it should work though, as the animation is set to stay in the transformed state after it's complete, so we just need to add the longer time between and it'll work.

Also note: this PR doesn't include other style improvements (eg. score styles)

https://github.com/paloobi/war_rune/assets/8248496/329b613b-b6b5-4d2d-ab76-9890f7cb2ff3

Closes #51 


