### PR TITLE
don't throw error if spectator joins

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,8 +35,14 @@ function App() {
     });
   }, []);
 
-  if (!game) {
-    return <div>Loading...</div>;
+  if (!game || !playerId) {
+    return (
+      <div>
+        Sorry!
+        <br /> We don't support Spectator View yet...
+        <br /> coming soon!
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
Currently, the game is throwing a critical error if a spectator joins, because there is no player object, and Game.tsx throws if no player is found in React Context.

This prevents the critical error being thrown (and just loads some text explaining spectator view is not supported)