### PR TITLE
remove footer with credits

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -62,6 +62,20 @@ img {
   background-color: #C7D7EC;
 }
 
+
+footer {
+  position: fixed;
+  bottom: 0;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 14px;
+  line-height: 1;
+}
+
+footer p {
+  margin: 8px;
+  color: #000;
+}
+
 .player_debug_info {
   display: flex;
   flex-direction: column;

--- a/src/App.css
+++ b/src/App.css
@@ -62,20 +62,6 @@ img {
   background-color: #C7D7EC;
 }
 
-
-footer {
-  position: fixed;
-  bottom: 0;
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 14px;
-  line-height: 1;
-}
-
-footer p {
-  margin: 8px;
-  color: #000;
-}
-
 .player_debug_info {
   display: flex;
   flex-direction: column;

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -111,26 +111,6 @@ const Game = () => {
           <PlayerPanel />
         </div>
       )}
-      {game.stage === GameStage.Start ||
-        (game.stage === GameStage.ClassSelect && (
-          <footer>
-            <p>
-              <small>
-                Made by <a href="https://github.com/dyazdani">@dyazdani</a>{" "}
-                <a href="https://github.com/jvaneyken">@jvaneyken</a>{" "}
-                <a href="https://github.com/paloobi/">@paloobi</a> for React Jam
-                Fall 2023
-              </small>
-            </p>
-            <p>
-              <small>
-                logo by{" "}
-                <a href="https://github.com/AnthonyPinto">@anthonypinto</a> -
-                art from <a href="https://kenney.nl/">Kenney.nl</a>
-              </small>
-            </p>
-          </footer>
-        ))}
     </div>
   );
 };

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -116,18 +116,11 @@ const Game = () => {
           <footer>
             <p>
               <small>
-                Made by <a href="https://github.com/dyazdani">@dyazdani</a>{" "}
-                <a href="https://github.com/jvaneyken">@jvaneyken</a>{" "}
-                <a href="https://github.com/paloobi/">@paloobi</a> for React Jam
-                Fall 2023
+                Made by @dyazdani @jvaneyken @paloobi for React Jam Fall 2023
               </small>
             </p>
             <p>
-              <small>
-                logo by{" "}
-                <a href="https://github.com/AnthonyPinto">@anthonypinto</a> -
-                art from <a href="https://kenney.nl/">Kenney.nl</a>
-              </small>
+              <small>logo by @anthonypinto and card art from Kenney.nl</small>
             </p>
           </footer>
         ))}

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -111,6 +111,26 @@ const Game = () => {
           <PlayerPanel />
         </div>
       )}
+      {game.stage === GameStage.Start ||
+        (game.stage === GameStage.ClassSelect && (
+          <footer>
+            <p>
+              <small>
+                Made by <a href="https://github.com/dyazdani">@dyazdani</a>{" "}
+                <a href="https://github.com/jvaneyken">@jvaneyken</a>{" "}
+                <a href="https://github.com/paloobi/">@paloobi</a> for React Jam
+                Fall 2023
+              </small>
+            </p>
+            <p>
+              <small>
+                logo by{" "}
+                <a href="https://github.com/AnthonyPinto">@anthonypinto</a> -
+                art from <a href="https://kenney.nl/">Kenney.nl</a>
+              </small>
+            </p>
+          </footer>
+        ))}
     </div>
   );
 };


### PR DESCRIPTION
Per the rules about Ads, Branding and Links, we need to remove the credits from the view in order to get approved for the Rune App
https://developers.rune.ai/docs/publishing/best-practices/#avoid-ads-branding-and-links

Tested locally and layouts still work as expected:
<img width="660" alt="Screenshot 2023-11-01 at 10 53 14 AM" src="https://github.com/paloobi/war_rune/assets/8248496/6c64c486-67e2-4d88-b6f8-79a8b66d84ab">
<img width="663" alt="Screenshot 2023-11-01 at 10 53 19 AM" src="https://github.com/paloobi/war_rune/assets/8248496/a8ebd96a-ea5c-42f5-90e0-6a22615edbf6">
<img width="675" alt="Screenshot 2023-11-01 at 10 53 23 AM" src="https://github.com/paloobi/war_rune/assets/8248496/3d978f1a-0a86-491d-93b2-2a1f6ba749f6">
